### PR TITLE
remove confusing/unnecessary words and plurals

### DIFF
--- a/proposals/XXXX-extend-property-wrappers-to-function-and-closure-parameters.md
+++ b/proposals/XXXX-extend-property-wrappers-to-function-and-closure-parameters.md
@@ -146,7 +146,7 @@ Property wrappers are essentially sugar wrapping a given property with compiler 
 
 ### Property Wrappers on Function Parameters
 
-Function parameters marked with a set of compatible property-wrapper custom attributes must conform to the following rules:
+A function parameter marked with property-wrapper custom attributes must conform to the following rules:
 
 1. Property wrapper function parameters must support initialization through their `wrappedValue` type. Therefore, all property-wrapper types must provide a suitable `init(wrappedValue:)`.
 2. Each `wrappedValue` getter shall be `nonmutating`.


### PR DESCRIPTION
I was confused by “compatible;” since it's not defined anywhere here I'm assuming it doesn't have special meaning.