### PR TITLE
Fix `AsyncLet` initializer.

### DIFF
--- a/proposals/0317-async-let.md
+++ b/proposals/0317-async-let.md
@@ -797,12 +797,10 @@ One problem with this approach is that property wrappers cannot provide the sema
 
 ```swift
 @propertyWrapper
-class AsyncLet<Wrapped: Sendable> {
+final class AsyncLet<Wrapped: Sendable> {
   var task: Task<Wrapped, Error>
   
-  // 'fn' cannot accept an @autoclosure because the initializer would have
-  // to be 'async'
-  init(wrappedValue fn: @Sendable @escaping () async throws -> Wrapped) {
+  init(wrappedValue fn: @Sendable @escaping @autoclosure () async throws -> Wrapped) {
     self.task = Task.detached {  // have to produce a detached task; cannot create a child task
       try await fn()
     }

--- a/proposals/0317-async-let.md
+++ b/proposals/0317-async-let.md
@@ -800,7 +800,9 @@ One problem with this approach is that property wrappers cannot provide the sema
 class AsyncLet<Wrapped: Sendable> {
   var task: Task<Wrapped, Error>
   
-  init(wrappedValue fn: @autoclosure(escaping) @Sendable () async throws -> Wrapped) {
+  // 'fn' cannot accept an @autoclosure because the initializer would have
+  // to be 'async'
+  init(wrappedValue fn: @Sendable @escaping () async throws -> Wrapped) {
     self.task = Task.detached {  // have to produce a detached task; cannot create a child task
       try await fn()
     }


### PR DESCRIPTION
The `AsyncLet` initializer's `fn` parameter has a function type marked `@autoclosure(escaping)`, which seems to be invalid syntax. Furthermore, using an auto closure in a function-like declaration requires that that declaration be `async` as well. I'm not sure if this limitation has been lifted, so please let me know if that's the case. 
