### PR TITLE
Nnnn refining property wrapper related initialization patch 1

### DIFF
--- a/proposals/NNNN-refining-property-wrapper-related-initialization.md
+++ b/proposals/NNNN-refining-property-wrapper-related-initialization.md
@@ -75,7 +75,7 @@ struct MixedRectangle {
 }
 ```
 
-would recieve a synthesized memberwise initializer that looks like:
+would receive a synthesized memberwise initializer that looks like:
 
 ```swift
 init(@SmallNumber height: Int = 1, @SmallNumber(maximum: 9) width: Int = 2) {
@@ -83,7 +83,7 @@ init(@SmallNumber height: Int = 1, @SmallNumber(maximum: 9) width: Int = 2) {
 }
 ```
 
-Second, we propose allowing property wrapper storage for global, type, and local wrapped properties to be initialized via the `init(projectedValue:)` system (as discussed in the future directions of SE-0293). E.g.:
+Second, we propose allowing property wrapper storage for global, type, and local wrapped properties to be initialized via the `init(projectedValue:)` system (as discussed in the [future directions of SE-0293](https://github.com/apple/swift-evolution/blob/main/proposals/0293-extend-property-wrappers-to-function-and-closure-parameters.md#generalized-property-wrapper-initialization-from-a-projection)). E.g.:
 
 ```swift
 @Wrapper
@@ -162,7 +162,7 @@ struct MyView: View {
     }
 }
 
-MyView(x: .constant(5))  // ❌old init
+MyView(x: .constant(5))  // ❌ old init
 MyView($x: .constant(5)) // ✅ new init
 ```
 

--- a/proposals/NNNN-refining-property-wrapper-related-initialization.md
+++ b/proposals/NNNN-refining-property-wrapper-related-initialization.md
@@ -23,47 +23,33 @@ Examples:
 
 ```swift
 @propertyWrapper
-struct WrapperWithDefaultInit<T> {
-  init() { fatalError() }
-
-  init(wrappedValue: T) {
-    self.wrappedValue = wrappedValue
-  }
-
-  let wrappedValue: T
+struct Wrapper {
+    let wrappedValue: Int
+    
+    init(wrappedValue: Int = 5) {
+        self.wrappedValue = wrappedValue
+    }
 }
 
 @propertyWrapper
-struct WrapperWithArgs<T> {
-  init(wrappedValue: T, extraArg: Bool) {
-    self.wrappedValue = wrappedValue
-  }
-
-  let wrappedValue: T
+struct ArgumentWrapper {
+    let wrappedValue: Int
+    let arg: Int
 }
 
-@propertyWrapper
-struct WrapperWithDefaultArgs<T> {
-  init(wrappedValue: T, extraArg: Bool = true) {
-    self.wrappedValue = wrappedValue
-  }
-
-  let wrappedValue: T
+struct Client {
+    @Wrapper var a
+    @Wrapper var b = 2
+    @ArgumentWrapper var c: Int
+    @ArgumentWrapper(arg: 0) var d = 17
 }
 
-struct S {
-  @WrapperWithDefaultInit var value1: Int
-  @WrapperWithDefaultInit var value2: Int = 7
-  @WrapperWithArgs var value3: Int
-  @WrapperWithArgs(extraArg: true) var value4: Int = 17
-  @WrapperWithDefaultArgs var value5: Int
-}
-
-let s = S(value1: WrapperWithDefaultInit(wrappedValue: 1),
-          value2: 2,
-          value3: WrapperWithArgs(wrappedValue: 3, extraArg: true),
-          value4: 4,
-          value5: 5)
+let client = Client(
+    a: Wrapper(wrappedValue: 1),
+    b: 2,
+    c: ArgumentWrapper(wrappedValue: 3, arg: 0),
+    d: 4
+)
 ```
 
 The result is that the author of a type with wrapped properties cannot easily determine or control what the signature of their memberwise initializer will look like; instead, it relies on subtle interactions between the property wrapper type, the declaration of the wrapped property, and how that property is initialized.

--- a/proposals/NNNN-refining-property-wrapper-related-initialization.md
+++ b/proposals/NNNN-refining-property-wrapper-related-initialization.md
@@ -7,7 +7,7 @@
 
 ## Introduction
 
-[SE 0258](https://github.com/apple/swift-evolution/blob/master/proposals/0258-property-wrappers.md) introduced property wrappers; due to their complexity, though, there were some inconsistencies. Function-like declarations were unsupported until [SE 0293](https://github.com/apple/swift-evolution/blob/main/proposals/0293-extend-property-wrappers-to-function-and-closure-parameters.md#detailed-design). These initial inconsistencies combined with the limited-scope 0293 features fragmented property-wrapper-related initialization. Namely, memberwise initializers use complex, poorly documented rules and projection initialization is reserved solely for function parameters.
+[SE 0258](https://github.com/apple/swift-evolution/blob/master/proposals/0258-property-wrappers.md) introduced property wrappers and [SE 0293](https://github.com/apple/swift-evolution/blob/main/proposals/0293-extend-property-wrappers-to-function-and-closure-parameters.md#detailed-design) expanded them with function-like declarations. Today, property wrapper initialization exhibits inconsistencies due to its growing versatility. Specifically, memberwise initializers use complex, poorly documented rules and projection initialization remains limited. This proposal will simplify synthesized memberwise initialization for types with wrapped properties and extend projection value initialization to include global, type, and local wrapped properties.
 
 ## Motivation
 

--- a/proposals/NNNN-refining-property-wrapper-related-initialization.md
+++ b/proposals/NNNN-refining-property-wrapper-related-initialization.md
@@ -19,6 +19,53 @@ Today, the rules for how wrapped properties are represented in the synthesized m
 - If there's no `init(wrappedValue:)` initializer, the memberwise initializer will use the property wrapper's type itself (i.e. `MyView(value: Binding<Int>)`).
 - If `init(wrappedValue:)` takes extra arguments without default values, the memberwise initializer uses the property wrapper type unless the wrapped property is initialized in-line with `=`.
 
+Examples:
+
+```swift
+@propertyWrapper
+struct WrapperWithDefaultInit<T> {
+  init() { fatalError() }
+
+  init(wrappedValue: T) {
+    self.wrappedValue = wrappedValue
+  }
+
+  let wrappedValue: T
+}
+
+@propertyWrapper
+struct WrapperWithArgs<T> {
+  init(wrappedValue: T, extraArg: Bool) {
+    self.wrappedValue = wrappedValue
+  }
+
+  let wrappedValue: T
+}
+
+@propertyWrapper
+struct WrapperWithDefaultArgs<T> {
+  init(wrappedValue: T, extraArg: Bool = true) {
+    self.wrappedValue = wrappedValue
+  }
+
+  let wrappedValue: T
+}
+
+struct S {
+  @WrapperWithDefaultInit var value1: Int
+  @WrapperWithDefaultInit var value2: Int = 7
+  @WrapperWithArgs var value3: Int
+  @WrapperWithArgs(extraArg: true) var value4: Int = 17
+  @WrapperWithDefaultArgs var value5: Int
+}
+
+let s = S(value1: WrapperWithDefaultInit(wrappedValue: 1),
+          value2: 2,
+          value3: WrapperWithArgs(wrappedValue: 3, extraArg: true),
+          value4: 4,
+          value5: 5)
+```
+
 The result is that the author of a type with wrapped properties cannot easily determine or control what the signature of their memberwise initializer will look like; instead, it relies on subtle interactions between the property wrapper type, the declaration of the wrapped property, and how that property is initialized.
 
 Furthermore, the current ruleset can implicitly expose the private storage of the property wrapper via the (implicitly `internal`) synthesized initializer. This behavior may be undesirable, and for a given wrapper there may be no way for a user to avoid it other than giving up on the synthesized initializer altogether and defining their own.


### PR DESCRIPTION
Hey Filip, Freddy,

I see that you made quick work of the pitch draft today! In this pr, I've added an alternative intro option for the pitch. 

I also think it would be great to put the init examples that were presented in the forums.swift discussion thread for this pitch in our motivation section. Freddy, the breadth of examples you offered in the Placeholder Type pitch helped me get started in reading proposals so I'm thinking of that here. I personally have difficulty understanding concepts until I see or write some code and similarly, I only began to understand the issues with the memberwise init rules as they stand when I saw the example code in the discussion. However, I do understand if they are too verbose, and in which case, perhaps we can just omit the entirety and just add a direct link to Holly's comment with the examples.

